### PR TITLE
Luaprofiler outputs a header line in its profile.out files. Summary.lua c

### DIFF
--- a/src/analyzer/summary.lua
+++ b/src/analyzer/summary.lua
@@ -43,6 +43,7 @@ function CreateSummary(lines, summary)
         total_time = string.gsub(total_time, ",", ".")
         
         if not (local_time and total_time) then return global_time end
+        if tonumber(local_time) == nil then return global_time end
         if summary[word] == nil then
 			summary[word] = {};
 			summary[word]["info"] = {}


### PR DESCRIPTION
Luaprofiler outputs a header line in its profile.out files. Summary.lua currently doesn't account for that line, resulting in error when local_time is not actually a number and trying to add it into global_time

A sample of the header is as follows:
stack_level file_defined    function_name   line_defined    current_line    local_time  total_time
0   (C) profiler_init   -1  -1  0.000013    0.000013
1   =[C]    called from print   -1  -1  0.000004    0.000005
0   =[C]    print   -1  26  0.000026    0.000031
